### PR TITLE
make Point repr easier on the eye

### DIFF
--- a/geometer/point.py
+++ b/geometer/point.py
@@ -151,7 +151,7 @@ class Point(ProjectiveElement):
         return (-1) * self
 
     def __repr__(self):
-        return "Point({})".format(",".join(self.normalized_array[:-1].astype(str))) + (" at Infinity" if np.isclose(self.array[-1], 0) else "")
+        return "Point({})".format(", ".join(self.normalized_array[:-1].astype(str))) + (" at Infinity" if np.isclose(self.array[-1], 0) else "")
 
     @property
     def normalized_array(self):


### PR DESCRIPTION
Add white space after comma in `Point repr` so output is like this: `Point(0.0, 0.0, 0.0, 0.0)`, instead of like that `Point(0.0,0.0,0.0,0.0)`