### PR TITLE
Fix conic-conic intersections

### DIFF
--- a/geometer/curve.py
+++ b/geometer/curve.py
@@ -471,7 +471,7 @@ class Conic(Quadric):
                     - 18 * alpha * beta * gamma * delta
                     + 27 * alpha ** 2 * delta ** 3
                 )
-                Q = W - alpha * csqrt(27 * D)
+                Q = W - 3 * alpha * csqrt(3 * D)
                 R = np.complex128(4 * Q) ** (1 / 3)
 
                 lam = 2 * beta ** 2 - 6 * alpha * gamma - beta + R

--- a/geometer/curve.py
+++ b/geometer/curve.py
@@ -25,7 +25,7 @@ from .base import (
     EQ_TOL_ABS,
 )
 from .exceptions import NotReducible
-from .utils import hat_matrix, is_multiple, adjugate, det, inv, matmul
+from .utils import hat_matrix, is_multiple, adjugate, det, inv, matmul, roots
 
 
 class Quadric(ProjectiveElement):
@@ -463,22 +463,10 @@ class Conic(Quadric):
                 gamma = det([a1, b2, b3]) + det([b1, a2, b3]) + det([b1, b2, a3])
                 delta = det(other.array)
 
-                W = -2 * beta ** 3 + 9 * alpha * beta * gamma - 27 * alpha ** 2 * delta
-                D = (
-                    -(beta ** 2) * gamma ** 2
-                    + 4 * alpha * gamma ** 3
-                    + 4 * beta ** 3 * delta
-                    - 18 * alpha * beta * gamma * delta
-                    + 27 * alpha ** 2 * delta ** 3
-                )
-                Q = W - 3 * alpha * csqrt(3 * D)
-                R = np.complex128(4 * Q) ** (1 / 3)
-
-                lam = 2 * beta ** 2 - 6 * alpha * gamma - beta + R
-                mu = 3 * alpha * (R + 3)
+                sol = roots([alpha, beta, gamma, delta])
 
                 c = Conic(
-                    lam * self.array + mu * other.array,
+                    sol[0] * self.array + other.array,
                     is_dual=self.is_dual,
                     copy=False,
                 )

--- a/geometer/utils/__init__.py
+++ b/geometer/utils/__init__.py
@@ -8,6 +8,7 @@ from .math import (
     inv,
     matmul,
     matvec,
+    roots,
 )
 from .indexing import posify_index, normalize_index, sanitize_index
 

--- a/geometer/utils/math.py
+++ b/geometer/utils/math.py
@@ -373,6 +373,25 @@ def matvec(a, b, transpose_a=False, adjoint_a=False, **kwargs):
 
 
 def roots(p):
+    r"""Calculates the roots of a polynomial for the given coefficients.
+
+    The polynomial is defined as
+
+    .. math::
+
+        p[0] x^n + p[1] x^{n-1} + \ldots + p[n-1] x + p[n].
+
+    Parameters
+    ----------
+    p : array_like
+        The coefficients of the polynomial.
+
+    Returns
+    -------
+    array_like
+        The roots of the polynomial.
+
+    """
     if len(p) == 4:
         a, b, c, d = p
     elif len(p) == 3:

--- a/geometer/utils/math.py
+++ b/geometer/utils/math.py
@@ -373,11 +373,16 @@ def matvec(a, b, transpose_a=False, adjoint_a=False, **kwargs):
 
 
 def roots(p):
-    # TODO: only use this for len(p) > 4
-    if len(p) != 4:
+    if len(p) == 4:
+        a, b, c, d = p
+    elif len(p) == 3:
+        a = 0
+        b, c, d = p
+    elif len(p) == 2:
+        a = b = 0
+        c, d = p
+    else:
         return np.roots(p)
-
-    a, b, c, d = p
 
     if a == 0 and b == 0:  # Linear equation
         return [-d / c]

--- a/geometer/utils/math.py
+++ b/geometer/utils/math.py
@@ -1,5 +1,6 @@
 import math
 import numpy as np
+from numpy.lib.scimath import sqrt as csqrt
 
 
 def is_multiple(a, b, axis=None, rtol=1.0e-15, atol=1.0e-8):
@@ -369,3 +370,57 @@ def matvec(a, b, transpose_a=False, adjoint_a=False, **kwargs):
         **kwargs
     )
     return np.squeeze(result, axis=-1)
+
+
+def roots(p):
+    # TODO: only use this for len(p) > 4
+    if len(p) != 4:
+        return np.roots(p)
+
+    a, b, c, d = p
+
+    if a == 0 and b == 0:  # Linear equation
+        return [-d / c]
+
+    elif a == 0:  # Quadratic equation
+        D = c ** 2 - 4 * b * d
+        D = csqrt(D)
+        x1 = (-c + D) / (2 * b)
+        x2 = (-c - D) / (2 * b)
+        return [x1, x2]
+
+    f = ((3 * c / a) - ((b ** 2) / (a ** 2))) / 3
+    g = (((2 * (b ** 3)) / (a ** 3)) - ((9 * b * c) / (a ** 2)) + (27 * d / a)) / 27
+    h = (g ** 2) / 4 + (f ** 3) / 27
+
+    if f == 0 and g == 0 and h == 0:  # All 3 roots are real and equal
+        x = np.cbrt(d / a)
+        return [x]
+
+    elif h <= 0:  # All 3 roots are real
+
+        i = np.sqrt(((g ** 2) / 4) - h)
+        j = np.cbrt(i)
+        k = np.arccos(-(g / (2 * i)))
+        L = j * -1
+        M = np.cos(k / 3)
+        N = np.sqrt(3) * np.sin(k / 3)
+        P = (b / (3 * a)) * -1
+
+        x1 = 2 * j * np.cos(k / 3) - (b / (3 * a))
+        x2 = L * (M + N) + P
+        x3 = L * (M - N) + P
+
+        return [x1, x2, x3]
+
+    elif h > 0:  # One real root and two complex roots
+        R = -(g / 2) + np.sqrt(h)
+        S = np.cbrt(R)
+        T = -(g / 2) - np.sqrt(h)
+        U = np.cbrt(T)
+
+        x1 = (S + U) - (b / (3 * a))
+        x2 = -(S + U) / 2 - (b / (3 * a)) + (S - U) * np.sqrt(3) * 0.5j
+        x3 = np.conj(x2)
+
+        return [x1, x2, x3]

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -139,6 +139,12 @@ class TestCircle:
             PointCollection([Point(2, 2), Point(0, 4)]),
         ]
 
+        c1 = Circle(Point(0, 0), 5)
+        c2 = Circle(Point(8, 0), 5)
+        intersections = c1.intersect(c2)
+        assert Point(4, 3) in intersections
+        assert Point(4, -3) in intersections
+
     def test_intersection_angle(self):
         c1 = Circle()
         c2 = Circle(Point(1, 1), 1)

--- a/tests/test_curve.py
+++ b/tests/test_curve.py
@@ -74,7 +74,7 @@ class TestConic:
 
         assert conic1 == conic2
 
-    def test_intersections(self):
+    def test_intersect(self):
         c = Circle(Point(0, 0), 1)
         i = c.intersect(Line(0, 1, 0))
         assert len(i) == 2
@@ -123,7 +123,7 @@ class TestCircle:
         c = Circle(Point(0, 1), 1)
         assert c.center == Point(0, 1)
 
-    def test_intersection(self):
+    def test_intersect(self):
         c = Circle(Point(0, 2), 2)
         l = Line(Point(-1, 2), Point(1, 2))
 
@@ -179,7 +179,7 @@ class TestQuadric:
 
 
 class TestSphere:
-    def test_intersection(self):
+    def test_intersect(self):
         s = Sphere(Point(0, 0, 2), 2)
         l = Line(Point(-1, 0, 2), Point(1, 0, 2))
 
@@ -235,7 +235,7 @@ class TestSphere:
 
 
 class TestCone:
-    def test_intersection(self):
+    def test_intersect(self):
         c = Cone(vertex=Point(1, 1, 1), base_center=Point(2, 2, 2), radius=2)
         a = np.sqrt(2)
         l = Line(Point(0, 4, 2), Point(4, 0, 2))
@@ -321,7 +321,7 @@ class TestQuadricCollection:
         q = QuadricCollection([Quadric.from_planes(e, f), Quadric.from_planes(g, h)])
         assert q.components == [PlaneCollection([e, g]), PlaneCollection([f, h])]
 
-    def test_intersection(self):
+    def test_intersect(self):
         q = QuadricCollection([Circle(Point(0, 1), 1), Circle(Point(0, 2), 2)])
         l = LineCollection(
             [Line(Point(-1, 1), Point(1, 1)), Line(Point(-1, 2), Point(1, 2))]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from geometer.utils import null_space, adjugate, det, inv
+from geometer.utils import null_space, adjugate, det, inv, roots
 import numpy as np
 
 
@@ -31,3 +31,12 @@ def test_inv():
 def test_null_space():
     a = np.array([[2, 3, 4, 3], [5, 1, 7, 6], [4, 7, 8, 1], [2, 3, 4, 3]])
     assert np.all(abs(a.dot(null_space(a))) < 1e-9)
+
+
+def test_roots():
+    np.random.seed(0)
+    polys = np.random.randint(-10, 10, size=(500, 4))
+    for p in polys:
+        sol = roots(p)
+        for x in sol:
+            assert np.isclose(np.polyval(p, x), 0)


### PR DESCRIPTION
The formula currently used to calculate the solutions of the equation `alpha*lam**3 + beta*lam*2*mu + gamma*lam*mu**2 + delta*mu**3 = 0` doesn't seem to work. It is based on the book Perspectives on Projective Geometry (page 198). We can replace that calculation with the simpler calculation of roots of the same equation with `mu = 1`.

This should solve #36.